### PR TITLE
Fix capabilities url TypeError

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -362,7 +362,7 @@ function run(ROOT,ID,PARAMETER,START,STOP,VERSION,REQ,RES) {
 			var timeoutFor = "defaultpreviousfail";			
 		};
 
-		url = ROOT + "/capabilities";
+		var url = ROOT + "/capabilities";
 		report(url);
 		//console.log(ip.address())
 		request({"url":url,"timeout": timeout(timeoutFor), "headers": {"Origin": ip.address()} },


### PR DESCRIPTION
This is my first commit on a public repo so please let me know if I need to change something and resubmit.

I was getting a TypeError exception on my capabilities endpoint, and adding var to the url instantiation appears to have fixed my issue and seems to follow the other functions' use of url.